### PR TITLE
Issue with install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This library contains 8 specialized nodes that enable seamless interaction with 
 
 1. Clone this repository to your Griptape Nodes workspace:
    ```bash
-   cd $(gtn config show | grep workspace_directory | cut -d'"' -f4)
+   cd $(gtn config show workspace_directory)
    git clone https://github.com/griptape-ai/griptape-nodes-library-neo4j.git
    ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This library contains 8 specialized nodes that enable seamless interaction with 
 1. Clone this repository to your Griptape Nodes workspace:
    ```bash
    cd $(gtn config show | grep workspace_directory | cut -d'"' -f4)
-   git clone https://github.com/your-repo/griptape-nodes-library-neo4j.git
+   git clone https://github.com/griptape-ai/griptape-nodes-library-neo4j.git
    ```
 
 2. Add the library to your Griptape Nodes engine:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This library contains 8 specialized nodes that enable seamless interaction with 
 
 1. Clone this repository to your Griptape Nodes workspace:
    ```bash
-   cd $(gtn config | grep workspace_directory | cut -d'"' -f4)
+   cd $(gtn config show | grep workspace_directory | cut -d'"' -f4)
    git clone https://github.com/your-repo/griptape-nodes-library-neo4j.git
    ```
 


### PR DESCRIPTION
Running this install command: cd $(gtn config | grep workspace_directory | cut -d'"' -f4) results in an error since gtn config no longer returns the config in json format. Putting gtn config show fixes this in more recent Griptape Nodes versions.